### PR TITLE
Fix global settings retrieval on connect

### DIFF
--- a/plugin/main.js
+++ b/plugin/main.js
@@ -16,6 +16,15 @@ function connectElgatoStreamDeckSocket(inPort, inPluginUUID, inRegisterEvent, in
         };
 
         websocket.send(JSON.stringify(json));
+
+        // Retrieve global settings (e.g., Maker Key) immediately after
+        // connecting so they are available for the first key press
+        const getGlobalSettings = {
+            "event": "getGlobalSettings",
+            "context": pluginUUID
+        };
+
+        websocket.send(JSON.stringify(getGlobalSettings));
     };
 
     websocket.onmessage = function (evt) {


### PR DESCRIPTION
## Summary
- ensure plugin loads global settings right after connecting to the Stream Deck WebSocket

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683fe3bc02a08329a998cc2ef3eb151c